### PR TITLE
Fix: Select ui component 수정

### DIFF
--- a/src/components/Home/TravelEvent.tsx
+++ b/src/components/Home/TravelEvent.tsx
@@ -81,6 +81,7 @@ const EventInfo = styled.div`
   span {
     font-weight: ${FONTWEGHT.fw500};
     font-size: ${FONTSIZE.fz16};
+    color: ${COLORS.ca6a6a6};
     line-height: 24px;
   }
 `

--- a/src/components/common/Select.tsx
+++ b/src/components/common/Select.tsx
@@ -1,32 +1,33 @@
 import { COLORS, FONTSIZE, FONTWEGHT } from '@src/styles/root'
-import React, { useState } from 'react'
+import React, { useRef, useState } from 'react'
 import styled from 'styled-components'
+import useOnClickOutside from '../hooks/useOnClickOutside'
 
 const Select = () => {
   const [currentValue, setCurrentValue] = useState('인기순')
   const [showOptions, setShowOptions] = useState(false)
-
-  console.log(showOptions)
+  const ref = useRef(null)
+  useOnClickOutside(ref, () => setShowOptions(false))
 
   const handleOnChangeSelectValue = (e: React.MouseEvent<HTMLLIElement, MouseEvent>) => {
     const { innerText } = e.target as HTMLLIElement
     setCurrentValue(innerText)
   }
   return (
-    <SelectBox onClick={() => setShowOptions((prev) => !prev)}>
-      <Label>{currentValue}</Label>
-      <SelectOptions show={showOptions}>
-        <Option onClick={(e) => handleOnChangeSelectValue(e)}>인기순</Option>
-        <Option onClick={(e) => handleOnChangeSelectValue(e)}>가격높은순</Option>
-        <Option onClick={(e) => handleOnChangeSelectValue(e)}>가격낮은순</Option>
-      </SelectOptions>
-    </SelectBox>
+    <SelectBoxStyle onClick={() => setShowOptions((prev) => !prev)}>
+      <LabelStyle>{currentValue}</LabelStyle>
+      <SelectOptionsStyle show={showOptions} ref={ref}>
+        <OptionStyle onClick={(e) => handleOnChangeSelectValue(e)}>인기순</OptionStyle>
+        <OptionStyle onClick={(e) => handleOnChangeSelectValue(e)}>가격높은순</OptionStyle>
+        <OptionStyle onClick={(e) => handleOnChangeSelectValue(e)}>가격낮은순</OptionStyle>
+      </SelectOptionsStyle>
+    </SelectBoxStyle>
   )
 }
 
 export default Select
 
-const SelectBox = styled.div`
+const SelectBoxStyle = styled.div`
   display: flex;
   align-items: center;
   position: relative;
@@ -48,11 +49,11 @@ const SelectBox = styled.div`
   }
 `
 
-const Label = styled.label`
+const LabelStyle = styled.label`
   font-size: ${FONTSIZE.fz14};
 `
 
-const SelectOptions = styled.ul`
+const SelectOptionsStyle = styled.ul`
   position: absolute;
   list-style: none;
   top: -1px;
@@ -68,7 +69,7 @@ const SelectOptions = styled.ul`
   box-sizing: content-box;
 `
 
-const Option = styled.li`
+const OptionStyle = styled.li`
   font-size: ${FONTSIZE.fz14};
   width: 108px;
   height: 43px;

--- a/src/components/hooks/useOnClickOutside.ts
+++ b/src/components/hooks/useOnClickOutside.ts
@@ -1,0 +1,19 @@
+import { RefObject, useEffect } from 'react'
+
+export default function useOnClickOutside<T extends HTMLElement>(
+  ref: RefObject<T>,
+  handler: (event: MouseEvent | TouchEvent) => void
+): void {
+  useEffect(() => {
+    const listener = (event: MouseEvent | TouchEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        handler(event)
+      }
+    }
+    document.addEventListener('click', listener, true)
+
+    return () => {
+      document.removeEventListener('click', listener, true)
+    }
+  }, [ref, handler])
+}


### PR DESCRIPTION
Select박스 외부영역을 클릭했을때 셀렉박스 닫기

## ✔️ 체크사항

- [x] 가장 최근 merge를 pull 받고 진행하는 것이 맞나요? 👉[최근 pr 확인 링크](https://github.com/KDT3-Final-6/final-project-FE/pulls)👈
- [x] merge 하는 곳이 develop 브랜치가 맞나요?
- [x] WBS 진행상황 및 라이브러리 업데이트를 진행했나요? 👉[FE WBS](https://docs.google.com/spreadsheets/d/1AQzrYa1IMbL9mLtnan5W2zdAc6FLdRXUBUAwxUElsLE/edit#gid=445575378)👈

## 💡 이슈 넘버

#39 

<!-- 간단한 설명도 추가해주세요 -->

## 🌐 변경 사항

<!-- 어떻게 해결했는지 과정을 나열하세요 -->

- Select ui component 수정
- Select 박스 이외 영역 클릭 시, Select 박스가 닫히도록 useOnClickOutside훅 추가함

## 🌐 공지 사항

<!-- Review 시 알아야 할 사항을 말씀하세요 -->

- `hooks` 디렉토리 추가