### PR TITLE
Fix: 마이페이지- 1:1문의페이지 refatching 데이터 실시간으로 가져오기

### DIFF
--- a/src/components/MyPage/QuestionCard.tsx
+++ b/src/components/MyPage/QuestionCard.tsx
@@ -8,7 +8,6 @@ import { yupResolver } from '@hookform/resolvers/yup'
 import QnASelectBtn from '@components/MyPage/QnASelectBtn'
 import SelectItemModal from './SelectItemModal'
 import { usePostQnAMutation } from '@src/reduxStore/api/qnaApiSlice'
-import { unwrapResult } from '@reduxjs/toolkit'
 
 type Option = {
   id: number

--- a/src/pages/Mypage/OneOnOne.tsx
+++ b/src/pages/Mypage/OneOnOne.tsx
@@ -2,15 +2,13 @@ import { getQnAList } from '@src/api/post'
 import Button from '@src/components/common/Button'
 import OneOnOneCard from '@src/components/MyPage/OneOnOneCard'
 import QuestionCard from '@src/components/MyPage/QuestionCard'
-import { qnaApi, useGetQnAListQuery } from '@src/reduxStore/api/qnaApiSlice'
+import { useGetQnAListQuery } from '@src/reduxStore/api/qnaApiSlice'
 import { COLORS, FONTSIZE, FONTWEGHT } from '@src/styles/root'
 import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import Paginate from '@src/components/common/Paginate'
 
-type Props = {}
-
-const OneOnOne = (props: Props) => {
+const OneOnOne = () => {
   const [isOpen, setIsOpen] = useState(false)
   const [page, setPage] = useState<number>(1)
 
@@ -22,8 +20,14 @@ const OneOnOne = (props: Props) => {
   const changePageHandler = (event: { selected: number }) => {
     setPage(event.selected + 1)
   }
-  const sortedQnAContents = qnaList && qnaList.content.sort((a, b) => b.postId - a.postId)
-  // console.log('sortedQnAContents', sortedQnAContents)
+
+  console.log('qnaList', qnaList)
+
+  // 정렬....
+  // const sortedQnAList = qnaList && {
+  //   ...qnaList,
+  //   content: [...qnaList.content].sort((a, b) => b.postId - a.postId),
+  // }
 
   return (
     <ContainerStyle>

--- a/src/reduxStore/api/orderApiSlice.ts
+++ b/src/reduxStore/api/orderApiSlice.ts
@@ -1,7 +1,7 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 // import { axiosInstance } from '@src/api/instance'
 import API_URL from '@src/constants/apiUrlConst'
-import { IOrders, IPostOrder } from '@src/interfaces/order'
+import { IOrders, IOrderContent } from '@src/interfaces/order'
 
 const API_BASE_URL: string = import.meta.env.VITE_BASE_URL
 
@@ -22,16 +22,19 @@ export const orderApi = createApi({
   reducerPath: 'orderApi',
   baseQuery,
   endpoints: (builder) => ({
-    getOrderList: builder.query<IOrders[], number | void>({
+    getOrderList: builder.query<IOrders, number | void>({
       query: (page = 1) => `${API_URL.order}?page=${page}`,
     }),
-    postOrder: builder.mutation<void, IPostOrder>({
+    postOrder: builder.mutation<void, IOrderContent>({
       query: (order) => ({
         url: API_URL.order,
         method: 'POST',
         body: order,
       }),
     }),
+    // postOrder: builder.query<IOrderContent, number | void>({
+    //   query: (page = 1) => `posts?page=${page}`,
+    // }),
     deleteOrder: builder.mutation<void, number>({
       query: (orderId) => ({
         url: `${API_URL.order}/${orderId}`,

--- a/src/reduxStore/api/qnaApiSlice.ts
+++ b/src/reduxStore/api/qnaApiSlice.ts
@@ -3,6 +3,17 @@ import API_URL from '@src/constants/apiUrlConst'
 import { IQnA, IPostQnA } from '@src/interfaces/post'
 
 const API_BASE_URL: string = import.meta.env.VITE_BASE_URL
+interface Post {
+  id: number
+  name: string
+}
+interface ListResponse<T> {
+  page: number
+  per_page: number
+  total: number
+  total_pages: number
+  data: T[]
+}
 
 // // API 엔드포인트의 각 함수를 추출
 const baseQuery = fetchBaseQuery({
@@ -24,6 +35,13 @@ export const qnaApi = createApi({
   endpoints: (builder) => ({
     getQnAList: builder.query<IQnA, number | void>({
       query: (page = 1) => `${API_URL.qna}?page=${page}`,
+      providesTags: (result, error, page) =>
+        result
+          ? [
+              ...result.content.map(({ postId }) => ({ type: 'QnA' as const, postId })),
+              { type: 'QnA', id: 'PARTIAL-LIST' },
+            ]
+          : [{ type: 'QnA', id: 'PARTIAL-LIST' }],
     }),
     postQnA: builder.mutation<void, IPostQnA>({
       query: (qna) => ({
@@ -31,12 +49,14 @@ export const qnaApi = createApi({
         method: 'POST',
         body: qna,
       }),
+      invalidatesTags: [{ type: 'QnA', id: 'PARTIAL-LIST' }],
     }),
     deleteQnA: builder.mutation<void, number>({
       query: (postId) => ({
         url: `${API_URL.qna}/${postId}`,
         method: 'DELETE',
       }),
+      invalidatesTags: (result, error, postId) => [{ type: 'QnA', id: postId }],
     }),
   }),
 })

--- a/src/reduxStore/modalSlice.ts
+++ b/src/reduxStore/modalSlice.ts
@@ -1,20 +1,20 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { createSlice } from '@reduxjs/toolkit'
 
-const modal = createSlice({
+const modalSlice = createSlice({
   name: 'modal',
   initialState: {
     isOpen: false,
     text: '',
     route: '',
-    onClickOK: () => { },
-    onClickCancel: () => { },
+    onClickOK: () => {},
+    onClickCancel: () => {},
   },
   reducers: {
     setModal(state, action) {
       return (state = action.payload)
-    }
-  }
+    },
+  },
 })
 
-export const { setModal } = modal.actions
-export default modal
+export const { setModal } = modalSlice.actions
+export default modalSlice

--- a/src/reduxStore/rootReducer.ts
+++ b/src/reduxStore/rootReducer.ts
@@ -2,11 +2,11 @@ import { combineReducers } from 'redux'
 import { qnaApi } from './api/qnaApiSlice'
 import { orderApi } from './api/orderApiSlice'
 import loadingSlice from '@src/reduxStore/loadingSlice'
-import modal from '@src/reduxStore/modalSlice'
+import modalSlice from '@src/reduxStore/modalSlice'
 
 const rootReducer = combineReducers({
   loading: loadingSlice.reducer,
-  modal: modal.reducer,
+  modal: modalSlice.reducer,
   [qnaApi.reducerPath]: qnaApi.reducer,
   [orderApi.reducerPath]: orderApi.reducer,
 })

--- a/src/reduxStore/store.ts
+++ b/src/reduxStore/store.ts
@@ -1,11 +1,16 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { setupListeners } from '@reduxjs/toolkit/query/react'
+import { orderApi } from './api/orderApiSlice'
 import { qnaApi } from './api/qnaApiSlice'
 import rootReducer from './rootReducer'
 
 export const store = configureStore({
   reducer: rootReducer,
-  middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(qnaApi.middleware),
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({ serializableCheck: false }).concat([
+      qnaApi.middleware,
+      orderApi.middleware,
+    ]),
 })
 
 setupListeners(store.dispatch)


### PR DESCRIPTION
## ✔️ 체크사항

- [x] 가장 최근 merge를 pull 받고 진행하는 것이 맞나요? 👉[최근 pr 확인 링크](https://github.com/KDT3-Final-6/final-project-FE/pulls)👈
- [x] merge 하는 곳이 develop 브랜치가 맞나요?
- [x] WBS 진행상황 및 라이브러리 업데이트를 진행했나요? 👉[FE WBS](https://docs.google.com/spreadsheets/d/1AQzrYa1IMbL9mLtnan5W2zdAc6FLdRXUBUAwxUElsLE/edit#gid=445575378)👈

## 💡 이슈 넘버

<!-- 해결한 이슈의 카데고리와 해당 이슈넘버를 나열하세요 -->

#97 

<!-- 간단한 설명도 추가해주세요 -->

## 🌐 변경 사항

<!-- 어떻게 해결했는지 과정을 나열하세요 -->

- redux store 미들웨어에 { serializableCheck: false } 추가 [참고사이트]('https://guiyomi.tistory.com/116')
- apiSlice에 getQnAList에는 providesTags를 postQnA,deleteQnA invalidatesTags 추가함
-

## 🌐 공지 사항

<!-- Review 시 알아야 할 사항을 말씀하세요 -->
